### PR TITLE
fix outputing image to the browser before the content type header is sen...

### DIFF
--- a/Controller/Component/CaptchaComponent.php
+++ b/Controller/Component/CaptchaComponent.php
@@ -29,6 +29,9 @@
  *                  - Set response type and body via response object
  * 2014-06-04  DdP  - Add sessionPrefix default configuration parameter
  *                  - Add support for multiple captcha instantiations
+ * 2014-07-23  YLK  Capture the data from imagejpeg() in a variable using
+ *                  ob_start() and ob_get_clean() and then set it as the
+ *                  response body.
  *
  */
 App::uses('Component', 'Controller');
@@ -195,12 +198,12 @@ class CaptchaComponent extends Component
         // Capture the image in a variable
         ob_start();
         imagejpeg($image);
-        $stringImage = ob_get_clean();
+        $imageData = ob_get_clean();
         imagedestroy($image);
         
         // Set the image as the body of the response
         $this->response->type('jpg');
-        $this->response->body($stringImage);
+        $this->response->body($imageData);
         $this->response->disableCache();
     }
 

--- a/Controller/Component/CaptchaComponent.php
+++ b/Controller/Component/CaptchaComponent.php
@@ -192,8 +192,15 @@ class CaptchaComponent extends Component
         $this->Session->delete($sessionKey);
         $this->Session->write($sessionKey, $text);
 
+        // Capture the image in a variable
+        ob_start();
+        imagejpeg($image);
+        $stringImage = ob_get_clean();
+        imagedestroy($image);
+        
+        // Set the image as the body of the response
         $this->response->type('jpg');
-        $this->response->body(imagejpeg($image));
+        $this->response->body($stringImage);
         $this->response->disableCache();
     }
 


### PR DESCRIPTION
# The problem

The captcha image was sometimes sent with a `text/html` header and sometimes with its appropriate `image/jpeg` header.
# The explanation

The imagejpg() function actually returns a boolen value and the image itself is sent to the output buffer. So when passed as a parameter to `$this->response->body(imagejpeg($image));` the image is not set as the body of the response.
# The fix

Capture the output buffer content into a variable which then is passed as the body of the response.
